### PR TITLE
Change agreement lookup to have a composite key

### DIFF
--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -1,12 +1,6 @@
-using AutoFixture;
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 using TenancyInformationApi.Tests.V1.Helper;
 using TenancyInformationApi.V1.Boundary.Response;
-using TenancyInformationApi.V1.Factories;
 using TenancyInformationApi.V1.Infrastructure;
 
 namespace TenancyInformationApi.Tests
@@ -14,14 +8,14 @@ namespace TenancyInformationApi.Tests
     public static class E2ETestHelper
     {
 
-        public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context, string tenancyReference)
+        public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context, string tenancyReference = null)
         {
-            var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference);
-            context.UhTenure.Add(tenancyAgreement.UhTenureType);
-            context.UhTenancyAgreementsType.Add(tenancyAgreement.UhAgreementType);
+            var agreementLookup = TestHelper.CreateAgreementTypeLookup();
+            var tenureTypeLookup = TestHelper.CreateTenureTypeLookup();
+            var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference, agreementLookup.UhAgreementTypeId, tenureTypeLookup.UhTenureTypeId);
+            context.UhTenure.Add(tenureTypeLookup);
+            context.UhTenancyAgreementsType.Add(agreementLookup);
             context.SaveChanges();
-            tenancyAgreement.UhTenureType = null;
-            tenancyAgreement.UhAgreementType = null;
 
             context.UhTenancyAgreements.Add(tenancyAgreement);
             context.SaveChanges();
@@ -39,8 +33,8 @@ namespace TenancyInformationApi.Tests
                 Terminated = tenancyAgreement.IsTerminated.ToString(CultureInfo.CurrentCulture),
                 Service = tenancyAgreement.ServiceCharge?.ToString(CultureInfo.CurrentCulture),
                 OtherCharge = tenancyAgreement.OtherCharges?.ToString(CultureInfo.CurrentCulture),
-                AgreementType = $"{tenancyAgreement.UhAgreementTypeId}: {tenancyAgreement.UhAgreementType?.Description}",
-                TenureType = $"{tenancyAgreement.UhTenureTypeId}: {tenancyAgreement.UhTenureType?.Description}",
+                AgreementType = $"{tenancyAgreement.UhAgreementTypeId}: {agreementLookup?.Description}",
+                TenureType = $"{tenureTypeLookup.UhTenureTypeId}: {tenureTypeLookup?.Description}",
 
 
             };

--- a/TenancyInformationApi.Tests/TenancyInformationApi.Tests.csproj
+++ b/TenancyInformationApi.Tests/TenancyInformationApi.Tests.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <Folder Include="V1\Domain" />
-    <Folder Include="V1\E2ETests" />
     <Folder Include="V1\Helper" />
   </ItemGroup>
 

--- a/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
+++ b/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
@@ -16,23 +16,25 @@ namespace TenancyInformationApi.Tests.V1.Factories
         public void EntityContainsAppropriateData()
         {
             var uhTenancy = _fixture.Create<UhTenancyAgreement>();
-
-            var domainTenancy = uhTenancy.ToDomain();
+            var agreementTypeDescription = _fixture.Create<UhAgreementType>();
+            var domainTenancy = uhTenancy.ToDomain(agreementTypeDescription);
 
             domainTenancy.Tenure.Should().Contain(uhTenancy.UhTenureTypeId);
             domainTenancy.Tenure.Should().Contain(uhTenancy.UhTenureType.Description);
-            domainTenancy.Agreement.Should().Contain(uhTenancy.UhAgreementTypeId);
-            domainTenancy.Agreement.Should().Contain(uhTenancy.UhAgreementType.Description);
+            domainTenancy.Agreement.Should().Contain(agreementTypeDescription.UhAgreementTypeId.ToString());
+            domainTenancy.Agreement.Should().Contain(agreementTypeDescription.Description);
         }
 
         [Test]
         public void ToDomainCorrectlyFormatsData()
         {
             var uhTenancy = _fixture.Create<UhTenancyAgreement>();
+            var agreementTypeDescription = _fixture.Create<UhAgreementType>();
+
             var tagRef = uhTenancy.TenancyAgreementReference;
             uhTenancy.TenancyAgreementReference = $" {tagRef}   ";
 
-            var domainTenancy = uhTenancy.ToDomain();
+            var domainTenancy = uhTenancy.ToDomain(agreementTypeDescription);
             var commencementDate = uhTenancy.CommencementOfTenancy;
             var endDate = uhTenancy.EndOfTenancy;
 
@@ -52,14 +54,19 @@ namespace TenancyInformationApi.Tests.V1.Factories
                 IsTerminated = false,
                 TenancyAgreementReference = "12345/3"
             };
+            var typeLookup = new UhAgreementType
+            {
+                UhAgreementTypeId = "M",
+                Description = "describing"
+            };
 
-            tenure.ToDomain().Should().BeEquivalentTo(new Tenancy
+            tenure.ToDomain(typeLookup).Should().BeEquivalentTo(new Tenancy
             {
                 Present = true,
                 Terminated = false,
-                TenancyReference = "12345/3"
+                TenancyReference = "12345/3",
+                Agreement = "M: describing"
             });
-
         }
     }
 }

--- a/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -9,12 +9,31 @@ namespace TenancyInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static UhTenancyAgreement CreateDatabaseTenancyEntity(string tenancyReference)
+        public static UhTenancyAgreement CreateDatabaseTenancyEntity(string tenancyReference, string agreementTypeRef, string tenureTypeLookupId = null)
         {
-            var faker = new Fixture();
-            var fp = faker.Create<UhTenancyAgreement>();
-            fp.TenancyAgreementReference = tenancyReference;
+            var fixture = new Fixture();
+            var fp = fixture.Build<UhTenancyAgreement>()
+                .Without(ta => ta.UhTenureType)
+                .Create();
+            fp.UhTenureTypeId = tenureTypeLookupId ?? fp.UhTenureTypeId;
+            fp.TenancyAgreementReference = tenancyReference ?? fp.TenancyAgreementReference;
+            fp.UhAgreementTypeId = Convert.ToChar(agreementTypeRef);
             return fp;
+        }
+
+        public static UhTenureType CreateTenureTypeLookup()
+        {
+            var fixture = new Fixture();
+            return fixture.Create<UhTenureType>();
+        }
+
+        public static UhAgreementType CreateAgreementTypeLookup()
+        {
+            var fixture = new Fixture();
+            return fixture.Build<UhAgreementType>()
+                .With(a => a.LookupType, "ZAG")
+                .With(a => a.UhAgreementTypeId, fixture.Create<char>().ToString)
+                .Create();
         }
     }
 }

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -7,14 +7,14 @@ namespace TenancyInformationApi.V1.Factories
 {
     public static class TenancyFactory
     {
-        public static Tenancy ToDomain(this UhTenancyAgreement uhTenancyAgreement)
+        public static Tenancy ToDomain(this UhTenancyAgreement uhTenancyAgreement, UhAgreementType agreementType)
         {
             var tenure = uhTenancyAgreement?.UhTenureTypeId == null && uhTenancyAgreement?.UhTenureType?.Description == null
                 ? null
                 : $"{uhTenancyAgreement?.UhTenureTypeId}: {uhTenancyAgreement?.UhTenureType?.Description}";
-            var agreement = uhTenancyAgreement?.UhAgreementTypeId == null && uhTenancyAgreement?.UhAgreementType?.Description == null
+            var agreement = agreementType?.UhAgreementTypeId == null
                 ? null
-                : $"{uhTenancyAgreement?.UhAgreementTypeId}: {uhTenancyAgreement?.UhAgreementType?.Description}";
+                : $"{agreementType.UhAgreementTypeId.Trim()}: {agreementType.Description?.Trim()}";
 
             return new Tenancy
             {
@@ -33,8 +33,5 @@ namespace TenancyInformationApi.V1.Factories
                 Agreement = agreement
             };
         }
-
-        public static List<Tenancy> ToDomain(this IEnumerable<UhTenancyAgreement> uhTenancyAgreements) =>
-            uhTenancyAgreements.Select(tenancy => tenancy.ToDomain()).ToList();
     }
 }

--- a/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using TenancyInformationApi.V1.Domain;
 using TenancyInformationApi.V1.Factories;
 using TenancyInformationApi.V1.Infrastructure;
@@ -15,10 +17,16 @@ namespace TenancyInformationApi.V1.Gateways
 
         public Tenancy GetById(string id)
         {
-            return _uhContext
-                .UhTenancyAgreements
-                .Find(id)?
-                .ToDomain();
+            var tenancyAgreement = _uhContext.UhTenancyAgreements
+                .Include(ta => ta.UhTenureType)
+                .FirstOrDefault(ta => ta.TenancyAgreementReference == id);
+            if (tenancyAgreement == null) return null;
+
+            var agreementLookup = _uhContext.UhTenancyAgreementsType
+                .Where(a => a.LookupType == "ZAG")
+                .First(a => a.UhAgreementTypeId.Trim() == tenancyAgreement.UhAgreementTypeId.ToString());
+
+            return tenancyAgreement.ToDomain(agreementLookup);
         }
     }
 }

--- a/TenancyInformationApi/V1/Infrastructure/UhAgreementType.cs
+++ b/TenancyInformationApi/V1/Infrastructure/UhAgreementType.cs
@@ -1,15 +1,18 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.AspNetCore.Mvc;
 
 namespace TenancyInformationApi.V1.Infrastructure
 {
     [Table("lookup", Schema = "dbo")]
     public class UhAgreementType
     {
-        // [Column("lu_type")] private const string LookupType = "ZAG";
-        [StringLength(1)]
-        [Column("lu_ref"), Key] public string UhAgreementTypeId { get; set; }
+        [StringLength(3)]
+        [Column("lu_type")] public string LookupType { get; set; }
+
+        [StringLength(3)]
+        [Column("lu_ref")] public string UhAgreementTypeId { get; set; }
+
+        [MaxLength(80)]
         [Column("lu_desc")] public string Description { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Infrastructure/UhContext.cs
+++ b/TenancyInformationApi/V1/Infrastructure/UhContext.cs
@@ -7,6 +7,12 @@ namespace TenancyInformationApi.V1.Infrastructure
         public UhContext(DbContextOptions options) : base(options)
         { }
 
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<UhAgreementType>()
+                .HasKey(o => new { o.LookupType, o.UhAgreementTypeId });
+        }
+
         public DbSet<UhTenancyAgreement> UhTenancyAgreements { get; set; }
 
         public DbSet<UhAgreementType> UhTenancyAgreementsType { get; set; }

--- a/TenancyInformationApi/V1/Infrastructure/UhTenancyAgreement.cs
+++ b/TenancyInformationApi/V1/Infrastructure/UhTenancyAgreement.cs
@@ -14,7 +14,7 @@ namespace TenancyInformationApi.V1.Infrastructure
         [StringLength(12)] [Column("prop_ref")] public string PropertyReference { get; set; }
         [StringLength(20)] [Column("u_saff_rentacc")] public string PaymentReference { get; set; }
         [StringLength(3)] [Column("tenure")] public string UhTenureTypeId { get; set; }
-        [StringLength(1)] [Column("agr_type")] public string UhAgreementTypeId { get; set; }
+        [Column("agr_type")] public char UhAgreementTypeId { get; set; }
         [Column("present")] public bool IsPresent { get; set; }
         [Column("terminated")] public bool IsTerminated { get; set; }
         [Column("cur_bal")] public float? CurrentRentBalance { get; set; }
@@ -24,6 +24,5 @@ namespace TenancyInformationApi.V1.Infrastructure
         [Column("eot")] public DateTime? EndOfTenancy { get; set; }
 
         public UhTenureType UhTenureType { get; set; }
-        public UhAgreementType UhAgreementType { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Infrastructure/UhTenureType.cs
+++ b/TenancyInformationApi/V1/Infrastructure/UhTenureType.cs
@@ -7,7 +7,9 @@ namespace TenancyInformationApi.V1.Infrastructure
     public class UhTenureType
     {
         [StringLength(3)]
+        [Key]
         [Column("ten_type")] public string UhTenureTypeId { get; set; }
+        [StringLength(15)]
         [Column("ten_desc")] public string Description { get; set; }
     }
 }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,8 +4,8 @@ CREATE TABLE dbo.tenagree(
 	tag_ref char(11) NOT NULL PRIMARY KEY,
 	prop_ref char(12) NULL,
 	house_ref char(10) NULL,
-	cot Timestamp(0) NULL,
-	eot Timestamp(0) NULL,
+	cot timestamp(0) NULL,
+	eot timestamp(0) NULL,
 	tenure char(3) NULL,
 	present Boolean NOT NULL,
 	terminated Boolean NOT NULL,
@@ -17,11 +17,12 @@ CREATE TABLE dbo.tenagree(
 );
 
 CREATE TABLE dbo.lookup (
-    lu_ref char(100) NOT NULL PRIMARY KEY,
-    lu_desc char(100) NOT NULL
+    lu_ref char(3) NOT NULL,
+    lu_type char(3) NOT NULL,
+    lu_desc varchar(80) DEFAULT ''
 );
 
 CREATE TABLE dbo.tenure (
-    ten_type char(100) NOT NULL PRIMARY KEY,
-    ten_desc char(100) NOT NULL
+    ten_type char(3) NOT NULL PRIMARY KEY,
+    ten_desc char(15)
 );


### PR DESCRIPTION
This required removing the foreign key declaration on the agreement entity to instead manually join the lookup table. 