### PR TITLE
First implementation of list endpoint to retrieve all saved tenancies

### DIFF
--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using TenancyInformationApi.Tests.V1.Helper;
 using TenancyInformationApi.V1.Boundary.Response;
@@ -7,14 +8,12 @@ namespace TenancyInformationApi.Tests
 {
     public static class E2ETestHelper
     {
-
         public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context, string tenancyReference = null)
         {
-            var agreementLookup = TestHelper.CreateAgreementTypeLookup();
+            var agreementLookup = AddAgreementTypeToDatabase(context);
             var tenureTypeLookup = TestHelper.CreateTenureTypeLookup();
             var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference, agreementLookup.UhAgreementTypeId, tenureTypeLookup.UhTenureTypeId);
             context.UhTenure.Add(tenureTypeLookup);
-            context.UhTenancyAgreementsType.Add(agreementLookup);
             context.SaveChanges();
 
             context.UhTenancyAgreements.Add(tenancyAgreement);
@@ -35,11 +34,22 @@ namespace TenancyInformationApi.Tests
                 OtherCharge = tenancyAgreement.OtherCharges?.ToString(CultureInfo.CurrentCulture),
                 AgreementType = $"{tenancyAgreement.UhAgreementTypeId}: {agreementLookup?.Description}",
                 TenureType = $"{tenureTypeLookup.UhTenureTypeId}: {tenureTypeLookup?.Description}",
-
-
             };
+        }
 
+        private static UhAgreementType AddAgreementTypeToDatabase(UhContext context)
+        {
+            var agreementLookup = TestHelper.CreateAgreementTypeLookup();
+            context.UhTenancyAgreementsType.Add(agreementLookup);
+            try
+            {
+                context.SaveChanges();
+                return agreementLookup;
+            }
+            catch (InvalidOperationException)
+            {
+                return AddAgreementTypeToDatabase(context);
+            }
         }
     }
 }
-

--- a/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
+++ b/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using AutoFixture;
 using TenancyInformationApi.V1.Controllers;
 using FluentAssertions;
@@ -6,6 +8,7 @@ using NUnit.Framework;
 using TenancyInformationApi.V1.UseCase.Interfaces;
 using Moq;
 using TenancyInformationApi.V1.Boundary.Response;
+using TenancyInformationApi.V1.UseCase;
 
 namespace TenancyInformationApi.Tests.V1.Controllers
 {
@@ -14,12 +17,14 @@ namespace TenancyInformationApi.Tests.V1.Controllers
     {
         private TenancyInformationController _classUnderTest;
         private Mock<IGetTenancyByIdUseCase> _getByIdMock;
+        private Mock<IListTenancies> _listTenancies;
 
         [SetUp]
         public void SetUp()
         {
             _getByIdMock = new Mock<IGetTenancyByIdUseCase>();
-            _classUnderTest = new TenancyInformationController(_getByIdMock.Object);
+            _listTenancies = new Mock<IListTenancies>();
+            _classUnderTest = new TenancyInformationController(_getByIdMock.Object, _listTenancies.Object);
         }
 
         [Test]
@@ -52,6 +57,20 @@ namespace TenancyInformationApi.Tests.V1.Controllers
 
             response.Should().NotBeNull();
             response?.StatusCode.Should().Be(200);
+        }
+
+        [Test]
+        public void ListTenanciesReturnsRecordsObtainedFromTheUseCase()
+        {
+            var fixture = new Fixture();
+            var stubbedResponse = new ListTenanciesResponse
+            {
+                Tenancies = fixture.CreateMany<TenancyInformationResponse>().ToList()
+            };
+            _listTenancies.Setup(x => x.Execute()).Returns(stubbedResponse);
+            var response = _classUnderTest.ListTenancies() as ObjectResult;
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(stubbedResponse);
         }
     }
 }

--- a/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
+++ b/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using TenancyInformationApi.V1.Boundary.Response;
+
+namespace TenancyInformationApi.Tests.V1.E2ETests
+{
+    public class ListTenancies : IntegrationTests<Startup>
+    {
+        [Test]
+        public async Task IfThereAreNoTenanciesItWillReturnAnEmptyList()
+        {
+            var response = await CallApiListEndpointWithQueryString("").ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
+            returnedTenancies.Tenancies.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task WithNoQueryParametersWillListAllStoredTenancies()
+        {
+            var expectedResponses = new List<TenancyInformationResponse>
+            {
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
+            };
+
+            var response = await CallApiListEndpointWithQueryString("").ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
+            returnedTenancies.Tenancies.Should().BeEquivalentTo(expectedResponses);
+        }
+
+        private async Task<HttpResponseMessage> CallApiListEndpointWithQueryString(string query)
+        {
+            var uri = new Uri($"api/v1/tenancies{query}", UriKind.Relative);
+            return await Client.GetAsync(uri).ConfigureAwait(true);
+        }
+
+        private static async Task<ListTenanciesResponse> DeserializeResponse(HttpResponseMessage response)
+        {
+            var stringContent = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            var returnedTenancies = JsonConvert.DeserializeObject<ListTenanciesResponse>(stringContent);
+            return returnedTenancies;
+        }
+    }
+}

--- a/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
+++ b/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
@@ -38,7 +38,7 @@ namespace TenancyInformationApi.Tests.V1.Factories
             var commencementDate = uhTenancy.CommencementOfTenancy;
             var endDate = uhTenancy.EndOfTenancy;
 
-            domainTenancy.TenancyReference.Should().Be(tagRef);
+            domainTenancy.TenancyAgreementReference.Should().Be(tagRef);
             domainTenancy.CommencementOfTenancyDate.Should()
                 .Be($"{commencementDate.Value.Year:0000}-{commencementDate.Value.Month:00}-{commencementDate.Value.Day:00}");
             domainTenancy.EndOfTenancyDate.Should()
@@ -64,7 +64,7 @@ namespace TenancyInformationApi.Tests.V1.Factories
             {
                 Present = true,
                 Terminated = false,
-                TenancyReference = "12345/3",
+                TenancyAgreementReference = "12345/3",
                 Agreement = "M: describing"
             });
         }

--- a/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
+++ b/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
@@ -19,7 +19,7 @@ namespace TenancyInformationApi.Tests.V1.Factories
             var agreementTypeDescription = _fixture.Create<UhAgreementType>();
             var domainTenancy = uhTenancy.ToDomain(agreementTypeDescription);
 
-            domainTenancy.Tenure.Should().Contain(uhTenancy.UhTenureTypeId);
+            domainTenancy.Tenure.Should().Contain(uhTenancy.UhTenureType.UhTenureTypeId);
             domainTenancy.Tenure.Should().Contain(uhTenancy.UhTenureType.Description);
             domainTenancy.Agreement.Should().Contain(agreementTypeDescription.UhAgreementTypeId.ToString());
             domainTenancy.Agreement.Should().Contain(agreementTypeDescription.Description);

--- a/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
+++ b/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using TenancyInformationApi.V1.Domain;
+using TenancyInformationApi.V1.Factories;
+using TenancyInformationApi.V1.Gateways;
+using TenancyInformationApi.V1.UseCase;
+
+namespace TenancyInformationApi.Tests.V1.UseCase
+{
+    public class ListTenanciesTests
+    {
+        private ListTenancies _classUnderTest;
+        private Mock<ITenancyGateway> _mockGateway;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGateway = new Mock<ITenancyGateway>();
+            _classUnderTest = new ListTenancies(_mockGateway.Object);
+        }
+
+        [Test]
+        public void GivenNoQueryParametersExecuteCallsTheGatewayToGetRecords()
+        {
+            _mockGateway.Setup(x => x.ListTenancies()).Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute();
+            _mockGateway.Verify();
+        }
+
+        [Test]
+        public void ExecuteReturnsTenanciesFromTheGatewayMappedToResponses()
+        {
+            var fixture = new Fixture();
+            var stubbedTenancies = fixture.CreateMany<Tenancy>().ToList();
+            _mockGateway.Setup(x => x.ListTenancies()).Returns(stubbedTenancies);
+
+            _classUnderTest.Execute().Tenancies.Should().BeEquivalentTo(stubbedTenancies.ToResponse());
+        }
+    }
+}

--- a/TenancyInformationApi/Startup.cs
+++ b/TenancyInformationApi/Startup.cs
@@ -31,8 +31,8 @@ namespace TenancyInformationApi
 
         public IConfiguration Configuration { get; }
         private static List<ApiVersionDescription> _apiVersions { get; set; }
-        //TODO update the below to the name of your API
-        private const string ApiName = "Your API Name";
+
+        private const string ApiName = "Tenancy Information API";
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public static void ConfigureServices(IServiceCollection services)
@@ -126,6 +126,7 @@ namespace TenancyInformationApi
         private static void RegisterUseCases(IServiceCollection services)
         {
             services.AddScoped<IGetTenancyByIdUseCase, GetTenancyByIdUseCase>();
+            services.AddScoped<IListTenancies, ListTenancies>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TenancyInformationApi/V1/Boundary/Response/ListTenanciesResponse.cs
+++ b/TenancyInformationApi/V1/Boundary/Response/ListTenanciesResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace TenancyInformationApi.V1.Boundary.Response
+{
+    public class ListTenanciesResponse
+    {
+        public List<TenancyInformationResponse> Tenancies { get; set; }
+    }
+}

--- a/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
+++ b/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
@@ -3,6 +3,7 @@ using TenancyInformationApi.V1.Boundary.Response;
 using TenancyInformationApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using TenancyInformationApi.V1.UseCase;
 
 namespace TenancyInformationApi.V1.Controllers
 {
@@ -13,15 +14,29 @@ namespace TenancyInformationApi.V1.Controllers
     public class TenancyInformationController : BaseController
     {
         private readonly IGetTenancyByIdUseCase _getByIdUseCase;
-        public TenancyInformationController(IGetTenancyByIdUseCase getByIdUseCase)
+        private readonly IListTenancies _listTenancies;
+
+        public TenancyInformationController(IGetTenancyByIdUseCase getByIdUseCase, IListTenancies listTenancies)
         {
             _getByIdUseCase = getByIdUseCase;
+            _listTenancies = listTenancies;
+        }
+
+        /// <summary>
+        /// Lists and queries tenancies.
+        /// </summary>
+        /// <response code="200">Success!</response>
+        [ProducesResponseType(typeof(ListTenanciesResponse), StatusCodes.Status200OK)]
+        [HttpGet]
+        public IActionResult ListTenancies()
+        {
+            return Ok(_listTenancies.Execute());
         }
 
         /// <summary>
         /// Retrieve a single TenancyInformation object.
         /// </summary>
-        /// <response code="200">...</response>
+        /// <response code="200">Success!</response>
         /// <response code="400">tag_ref is malformed or missing.</response>
         /// <response code="404">No tenancy was found for the provided tag_ref.</response>
         [ProducesResponseType(typeof(TenancyInformationResponse), StatusCodes.Status200OK)]

--- a/TenancyInformationApi/V1/Domain/Tenancy.cs
+++ b/TenancyInformationApi/V1/Domain/Tenancy.cs
@@ -2,7 +2,7 @@ namespace TenancyInformationApi.V1.Domain
 {
     public class Tenancy
     {
-        public string TenancyReference { get; set; }
+        public string TenancyAgreementReference { get; set; }
         public string CommencementOfTenancyDate { get; set; }
         public string EndOfTenancyDate { get; set; }
         public float? CurrentBalance { get; set; }

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -9,9 +9,14 @@ namespace TenancyInformationApi.V1.Factories
     {
         public static Tenancy ToDomain(this UhTenancyAgreement uhTenancyAgreement, UhAgreementType agreementType)
         {
-            var tenure = uhTenancyAgreement?.UhTenureTypeId == null && uhTenancyAgreement?.UhTenureType?.Description == null
+            return uhTenancyAgreement.ToDomain(agreementType, uhTenancyAgreement.UhTenureType);
+        }
+
+        public static Tenancy ToDomain(this UhTenancyAgreement uhTenancyAgreement, UhAgreementType agreementType, UhTenureType tenureType)
+        {
+            var tenure = tenureType?.UhTenureTypeId == null && tenureType?.Description == null
                 ? null
-                : $"{uhTenancyAgreement?.UhTenureTypeId}: {uhTenancyAgreement?.UhTenureType?.Description}";
+                : $"{tenureType?.UhTenureTypeId}: {tenureType?.Description}";
             var agreement = agreementType?.UhAgreementTypeId == null
                 ? null
                 : $"{agreementType.UhAgreementTypeId.Trim()}: {agreementType.Description?.Trim()}";

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -23,7 +23,7 @@ namespace TenancyInformationApi.V1.Factories
 
             return new Tenancy
             {
-                TenancyReference = uhTenancyAgreement?.TenancyAgreementReference?.Trim(),
+                TenancyAgreementReference = uhTenancyAgreement?.TenancyAgreementReference?.Trim(),
                 CommencementOfTenancyDate = uhTenancyAgreement.CommencementOfTenancy?.ToString("yyyy-MM-dd"),
                 EndOfTenancyDate = uhTenancyAgreement.EndOfTenancy?.ToString("yyyy-MM-dd"),
                 CurrentBalance = uhTenancyAgreement.CurrentRentBalance,

--- a/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
@@ -12,7 +12,7 @@ namespace TenancyInformationApi.V1.Factories
         {
             return new TenancyInformationResponse
             {
-                TenancyAgreementReference = tenancy?.TenancyReference,
+                TenancyAgreementReference = tenancy?.TenancyAgreementReference,
                 CommencementOfTenancyDate = tenancy?.CommencementOfTenancyDate,
                 EndOfTenancyDate = tenancy?.EndOfTenancyDate,
                 CurrentBalance = tenancy?.CurrentBalance?.ToString(CultureInfo.CurrentCulture),

--- a/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using TenancyInformationApi.V1.Boundary.Response;
 using TenancyInformationApi.V1.Domain;
 
@@ -24,6 +26,11 @@ namespace TenancyInformationApi.V1.Factories
                 Service = tenancy?.Service?.ToString(CultureInfo.CurrentCulture),
                 OtherCharge = tenancy?.OtherCharge?.ToString(CultureInfo.CurrentCulture)
             };
+        }
+
+        public static List<TenancyInformationResponse> ToResponse(this IEnumerable<Tenancy> tenancies)
+        {
+            return tenancies.Select(x => x.ToResponse()).ToList();
         }
     }
 }

--- a/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
@@ -6,5 +6,6 @@ namespace TenancyInformationApi.V1.Gateways
     public interface ITenancyGateway
     {
         Tenancy GetById(string id);
+        List<Tenancy> ListTenancies();
     }
 }

--- a/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using TenancyInformationApi.V1.Domain;
@@ -27,6 +28,23 @@ namespace TenancyInformationApi.V1.Gateways
                 .First(a => a.UhAgreementTypeId.Trim() == tenancyAgreement.UhAgreementTypeId.ToString());
 
             return tenancyAgreement.ToDomain(agreementLookup);
+        }
+
+        public List<Tenancy> ListTenancies()
+        {
+            var tenancies = (
+                from agreements in _uhContext.UhTenancyAgreements
+                join tenureType in _uhContext.UhTenure on agreements.UhTenureTypeId equals tenureType.UhTenureTypeId
+                join agreementType in _uhContext.UhTenancyAgreementsType on agreements.UhAgreementTypeId.ToString()
+                    equals agreementType.UhAgreementTypeId.Trim()
+                where agreementType.LookupType == "ZAG"
+                select new
+                {
+                    Agreement = agreements,
+                    TenureType = tenureType,
+                    AgreementType = agreementType
+                });
+            return tenancies.Select(t => t.Agreement.ToDomain(t.AgreementType, t.TenureType)).ToList();
         }
     }
 }

--- a/TenancyInformationApi/V1/UseCase/IListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/IListTenancies.cs
@@ -1,0 +1,9 @@
+using TenancyInformationApi.V1.Boundary.Response;
+
+namespace TenancyInformationApi.V1.UseCase
+{
+    public interface IListTenancies
+    {
+        ListTenanciesResponse Execute();
+    }
+}

--- a/TenancyInformationApi/V1/UseCase/ListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/ListTenancies.cs
@@ -1,0 +1,25 @@
+using TenancyInformationApi.V1.Boundary.Response;
+using TenancyInformationApi.V1.Factories;
+using TenancyInformationApi.V1.Gateways;
+
+namespace TenancyInformationApi.V1.UseCase
+{
+    public class ListTenancies : IListTenancies
+    {
+        private readonly ITenancyGateway _gateway;
+
+        public ListTenancies(ITenancyGateway gateway)
+        {
+            _gateway = gateway;
+        }
+
+        public ListTenanciesResponse Execute()
+        {
+            var tenancies = _gateway.ListTenancies();
+            return new ListTenanciesResponse
+            {
+                Tenancies = tenancies.ToResponse()
+            };
+        }
+    }
+}


### PR DESCRIPTION
This endpoint is just returning everything in the `tenagree` table, joining with the two lookup tables to get tenure and agreement types.

Also renamed `TenancyReference` to `TenancyAgreementReference` in the domain object, even though it's more verbose I found it confusing with the shortened name.