### PR TITLE
[PA-268] Change Database name in connection string

### DIFF
--- a/TenancyInformationApi/serverless.yml
+++ b/TenancyInformationApi/serverless.yml
@@ -23,7 +23,7 @@ functions:
     handler: TenancyInformationApi::TenancyInformationApi.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
     environment:
-      CONNECTION_STRING: Host=${ssm:/uh-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/uh-api/${self:provider.stage}/postgres-port};Database=uh-mirror;Username=${ssm:/uh-api/${self:provider.stage}/postgres-username};Password=${ssm:/uh-api/${self:provider.stage}/postgres-password}
+      CONNECTION_STRING: Host=${ssm:/uh-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/uh-api/${self:provider.stage}/postgres-port};Database=uh-mirror-db-${self:provider.stage};Username=${ssm:/uh-api/${self:provider.stage}/postgres-username};Password=${ssm:/uh-api/${self:provider.stage}/postgres-password}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
This needs to be changed to reflect the naming of the RDS Postgres instances.