### PR TITLE
Implement cursor-limit pagination

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -125,6 +125,7 @@ dotnet_diagnostic.CA1032.severity = none
 dotnet_diagnostic.CA1062.severity = none
 dotnet_diagnostic.CA1303.severity = none
 dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1307.severity = none
 # Suppressed[CA1001] as not sure how to fix disposable fields within tests
 dotnet_diagnostic.CA1001.severity = none
 #Can reassign collections

--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -9,12 +9,11 @@ namespace TenancyInformationApi.Tests
 {
     public static class E2ETestHelper
     {
-        public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context, string tenancyReference = null)
+        public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context,
+            string tenancyReference = null, string agreementId = null, string tenureTypeId = null)
         {
-            var agreementLookup = AddAgreementTypeToDatabase(context);
-            var tenureTypeLookup = TestHelper.CreateTenureTypeLookup();
-            context.UhTenure.Add(tenureTypeLookup);
-            context.SaveChanges();
+            var agreementLookup = AddAgreementTypeToDatabase(context, agreementId);
+            var tenureTypeLookup = AddTenureTypeToDatabase(context, tenureTypeId);
 
             var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference, agreementLookup.UhAgreementTypeId, tenureTypeLookup.UhTenureTypeId);
             context.UhTenancyAgreements.Add(tenancyAgreement);
@@ -56,19 +55,22 @@ namespace TenancyInformationApi.Tests
             };
         }
 
-        private static UhAgreementType AddAgreementTypeToDatabase(UhContext context)
+        private static UhAgreementType AddAgreementTypeToDatabase(UhContext context, string agreementId = null)
         {
             var agreementLookup = TestHelper.CreateAgreementTypeLookup();
+            agreementLookup.UhAgreementTypeId = agreementId ?? agreementLookup.UhAgreementTypeId;
             context.UhTenancyAgreementsType.Add(agreementLookup);
-            try
-            {
-                context.SaveChanges();
-                return agreementLookup;
-            }
-            catch (InvalidOperationException)
-            {
-                return AddAgreementTypeToDatabase(context);
-            }
+            context.SaveChanges();
+            return agreementLookup;
+        }
+
+        private static UhTenureType AddTenureTypeToDatabase(UhContext context, string tenureTypeId = null)
+        {
+            var tenureLookup = TestHelper.CreateTenureTypeLookup();
+            tenureLookup.UhTenureTypeId = tenureTypeId ?? tenureLookup.UhTenureTypeId;
+            context.UhTenure.Add(tenureLookup);
+            context.SaveChanges();
+            return tenureLookup;
         }
     }
 }

--- a/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
+++ b/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
 using TenancyInformationApi.V1.Controllers;
@@ -63,11 +62,27 @@ namespace TenancyInformationApi.Tests.V1.Controllers
         public void ListTenanciesReturnsRecordsObtainedFromTheUseCase()
         {
             var fixture = new Fixture();
+            var limit = fixture.Create<int>();
+            var cursor = fixture.Create<int>();
             var stubbedResponse = new ListTenanciesResponse
             {
                 Tenancies = fixture.CreateMany<TenancyInformationResponse>().ToList()
             };
-            _listTenancies.Setup(x => x.Execute()).Returns(stubbedResponse);
+            _listTenancies.Setup(x => x.Execute(limit, cursor)).Returns(stubbedResponse);
+            var response = _classUnderTest.ListTenancies(limit, cursor) as ObjectResult;
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(stubbedResponse);
+        }
+
+        [Test]
+        public void ListTenanciesWillAssignDefaultValuesToLimitAndCursor()
+        {
+            var fixture = new Fixture();
+            var stubbedResponse = new ListTenanciesResponse
+            {
+                Tenancies = fixture.CreateMany<TenancyInformationResponse>().ToList()
+            };
+            _listTenancies.Setup(x => x.Execute(20, 0)).Returns(stubbedResponse);
             var response = _classUnderTest.ListTenancies() as ObjectResult;
             response.StatusCode.Should().Be(200);
             response.Value.Should().BeEquivalentTo(stubbedResponse);

--- a/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
+++ b/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
@@ -89,6 +89,7 @@ namespace TenancyInformationApi.Tests.V1.E2ETests
 
         private static string GetLetterFromAlphabetPosition(int position)
         {
+            // Being used to generate ordered string based ID's which are all unique. To help test pagination and prevent duplicate key errors in test setup.
             return Convert.ToChar(Enumerable.Range('a', 27).ElementAt(position)).ToString();
         }
 

--- a/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
+++ b/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Bogus;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -26,9 +28,9 @@ namespace TenancyInformationApi.Tests.V1.E2ETests
         {
             var expectedResponses = new List<TenancyInformationResponse>
             {
-                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
-                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
-                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "12345/2", "a", "x"),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "54326/9", "b", "y"),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "453627/2", "c", "z"),
             };
 
             var response = await CallApiListEndpointWithQueryString("").ConfigureAwait(true);
@@ -36,6 +38,58 @@ namespace TenancyInformationApi.Tests.V1.E2ETests
 
             var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
             returnedTenancies.Tenancies.Should().BeEquivalentTo(expectedResponses);
+        }
+
+        [Test]
+        public async Task WithNoCursorAndLimitWillReturnTheFirstPageOfTenanciesWithTheNextCursor()
+        {
+            var faker = new Faker();
+            var allSavedEntities = Enumerable.Range(0, 25)
+                .Select(r =>
+                {
+                    var tagRef = $"{r}{faker.Random.Int(1000, 9999):0000}/{faker.Random.Int(1, 9)}";
+                    var agreementId = GetLetterFromAlphabetPosition(r);
+                    var tenureId = GetLetterFromAlphabetPosition(r + 2);
+                    return E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, tagRef, agreementId, tenureId);
+                }).ToList();
+
+            var response = await CallApiListEndpointWithQueryString("").ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
+            returnedTenancies.Tenancies.Should().BeEquivalentTo(allSavedEntities.Take(20));
+
+            var finalTagRef = allSavedEntities.ElementAt(19).TenancyAgreementReference;
+            var expectedCursor = $"{finalTagRef.Substring(0, 6)}{finalTagRef.Substring(7, 1)}";
+            returnedTenancies.NextCursor.Should().Be(expectedCursor);
+        }
+
+        [Test]
+        public async Task WithCursorAndLimitGivenWillCorrectlyPaginateTenanciesReturned()
+        {
+            var faker = new Faker();
+            var allSavedEntities = Enumerable.Range(0, 17)
+                .Select(r =>
+                {
+                    var tagRef = $"{r}{faker.Random.Int(1000, 9999):0000}/{faker.Random.Int(1, 9)}";
+                    var agreementId = GetLetterFromAlphabetPosition(r);
+                    var tenureId = GetLetterFromAlphabetPosition(r + 2);
+                    return E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, tagRef, agreementId, tenureId);
+                }).ToList();
+
+            var finalTagRef = allSavedEntities.ElementAt(2).TenancyAgreementReference;
+            var cursor = $"{finalTagRef.Substring(0, 5)}{finalTagRef.Substring(6, 1)}";
+
+            var response = await CallApiListEndpointWithQueryString($"?limit=12&cursor={cursor}").ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
+            returnedTenancies.Tenancies.Should().BeEquivalentTo(allSavedEntities.Skip(3).Take(12));
+        }
+
+        private static string GetLetterFromAlphabetPosition(int position)
+        {
+            return Convert.ToChar(Enumerable.Range('a', 27).ElementAt(position)).ToString();
         }
 
         private async Task<HttpResponseMessage> CallApiListEndpointWithQueryString(string query)

--- a/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -18,7 +18,7 @@ namespace TenancyInformationApi.Tests.V1.Helper
                 .Create();
             fp.UhTenureTypeId = tenureTypeLookupId ?? fp.UhTenureTypeId;
             fp.TenancyAgreementReference = tenancyReference ?? fp.TenancyAgreementReference;
-            fp.UhAgreementTypeId = Convert.ToChar(agreementTypeRef);
+            fp.UhAgreementTypeId = agreementTypeRef.First();
             return fp;
         }
 
@@ -49,7 +49,7 @@ namespace TenancyInformationApi.Tests.V1.Helper
             var fixture = new Fixture();
             return fixture.Build<UhAgreementType>()
                 .With(a => a.LookupType, "ZAG")
-                .With(a => a.UhAgreementTypeId, fixture.Create<char>().ToString)
+                .With(a => a.UhAgreementTypeId, fixture.Create<string>().First().ToString)
                 .Create();
         }
     }

--- a/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
+++ b/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
+using Bogus;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -15,6 +16,7 @@ namespace TenancyInformationApi.Tests.V1.UseCase
     {
         private ListTenancies _classUnderTest;
         private Mock<ITenancyGateway> _mockGateway;
+        private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
@@ -26,19 +28,84 @@ namespace TenancyInformationApi.Tests.V1.UseCase
         [Test]
         public void GivenNoQueryParametersExecuteCallsTheGatewayToGetRecords()
         {
-            _mockGateway.Setup(x => x.ListTenancies()).Returns(new List<Tenancy>()).Verifiable();
-            _classUnderTest.Execute();
+            _mockGateway.Setup(x => x.ListTenancies(It.IsAny<int>(), It.IsAny<int>())).Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute(20, 0);
             _mockGateway.Verify();
         }
 
         [Test]
         public void ExecuteReturnsTenanciesFromTheGatewayMappedToResponses()
         {
-            var fixture = new Fixture();
-            var stubbedTenancies = fixture.CreateMany<Tenancy>().ToList();
-            _mockGateway.Setup(x => x.ListTenancies()).Returns(stubbedTenancies);
+            var stubbedTenancies = _fixture.CreateMany<Tenancy>().ToList();
+            _mockGateway.Setup(x => x.ListTenancies(It.IsAny<int>(), It.IsAny<int>())).Returns(stubbedTenancies);
 
-            _classUnderTest.Execute().Tenancies.Should().BeEquivalentTo(stubbedTenancies.ToResponse());
+            _classUnderTest.Execute(20, 0).Tenancies.Should().BeEquivalentTo(stubbedTenancies.ToResponse());
+        }
+
+        [Test]
+        public void ExecuteCallsTheGatewayWithLimitAndFormattedCursor()
+        {
+            _mockGateway.Setup(x => x.ListTenancies(23, 236712)).Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute(23, 236712);
+            _mockGateway.Verify();
+        }
+
+        [Test]
+        public void ExecuteIfNotCursorSuppliedPasses0ToTheGateway()
+        {
+            _mockGateway.Setup(x => x.ListTenancies(It.IsAny<int>(), 0)).Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute(20, 0);
+            _mockGateway.Verify();
+        }
+
+        [Test]
+        public void IfLimitLessThanTheMinimumWillUseTheMinimumLimit()
+        {
+            _mockGateway.Setup(x => x.ListTenancies(10, It.IsAny<int>()))
+                .Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute(0, 0);
+            _mockGateway.Verify();
+        }
+
+        [Test]
+        public void IfLimitMoreThanTheMaximumWillUseTheMaximumLimit()
+        {
+            _mockGateway.Setup(x => x.ListTenancies(100, It.IsAny<int>()))
+                .Returns(new List<Tenancy>()).Verifiable();
+            _classUnderTest.Execute(400, 0);
+            _mockGateway.Verify();
+        }
+
+        [Test]
+        public void ReturnsTheNextCursorFormattedCorrectly()
+        {
+            var faker = new Faker();
+            var stubbedResidents = _fixture.CreateMany<Tenancy>(10).Select((t, index) =>
+            {
+                var tagRef = $"{index}{faker.Random.Int(0, 9999):0000}/{faker.Random.Int(1, 9)}";
+                t.TenancyAgreementReference = tagRef;
+                return t;
+            }).ToList();
+
+            _mockGateway
+                .Setup(x => x.ListTenancies(10, It.IsAny<int>()))
+                .Returns(stubbedResidents);
+            var tagRefForNextCursor = stubbedResidents.Last().TenancyAgreementReference;
+            var expectedNextCursor = $"{tagRefForNextCursor.Substring(0, 5)}{tagRefForNextCursor.Substring(6, 1)}";
+
+            _classUnderTest.Execute(10, 0).NextCursor.Should().Be(expectedNextCursor);
+        }
+
+        [Test]
+        public void WhenAtTheEndOfTheResidentListReturnsNullForTheNextCursor()
+        {
+            var stubbedResidents = _fixture.CreateMany<Tenancy>(7);
+
+            _mockGateway.Setup(x =>
+                    x.ListTenancies(10, It.IsAny<int>()))
+                .Returns(stubbedResidents.ToList());
+
+            _classUnderTest.Execute(10, 0).NextCursor.Should().Be(null);
         }
     }
 }

--- a/TenancyInformationApi/V1/Boundary/Response/ListTenanciesResponse.cs
+++ b/TenancyInformationApi/V1/Boundary/Response/ListTenanciesResponse.cs
@@ -5,5 +5,6 @@ namespace TenancyInformationApi.V1.Boundary.Response
     public class ListTenanciesResponse
     {
         public List<TenancyInformationResponse> Tenancies { get; set; }
+        public string NextCursor { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
+++ b/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
@@ -28,9 +28,9 @@ namespace TenancyInformationApi.V1.Controllers
         /// <response code="200">Success!</response>
         [ProducesResponseType(typeof(ListTenanciesResponse), StatusCodes.Status200OK)]
         [HttpGet]
-        public IActionResult ListTenancies()
+        public IActionResult ListTenancies([FromQuery] int limit = 20, [FromQuery] int cursor = 0)
         {
-            return Ok(_listTenancies.Execute());
+            return Ok(_listTenancies.Execute(limit, cursor));
         }
 
         /// <summary>

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -29,9 +29,9 @@ namespace TenancyInformationApi.V1.Factories
 
         public static Tenancy ToDomain(this UhTenancyAgreement uhTenancyAgreement, UhAgreementType agreementType, UhTenureType tenureType, UHProperty property = null)
         {
-            var tenure = tenureType?.UhTenureTypeId == null && tenureType?.Description == null
+            var tenure = tenureType == null
                 ? null
-                : $"{tenureType?.UhTenureTypeId}: {tenureType?.Description}";
+                : $"{tenureType.UhTenureTypeId.Trim()}: {tenureType.Description.Trim()}";
             var agreement = agreementType?.UhAgreementTypeId == null
                 ? null
                 : $"{agreementType.UhAgreementTypeId.Trim()}: {agreementType.Description?.Trim()}";

--- a/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
@@ -6,6 +6,6 @@ namespace TenancyInformationApi.V1.Gateways
     public interface ITenancyGateway
     {
         Tenancy GetById(string id);
-        List<Tenancy> ListTenancies();
+        List<Tenancy> ListTenancies(int limit, int cursor);
     }
 }

--- a/TenancyInformationApi/V1/UseCase/IListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/IListTenancies.cs
@@ -4,6 +4,6 @@ namespace TenancyInformationApi.V1.UseCase
 {
     public interface IListTenancies
     {
-        ListTenanciesResponse Execute();
+        ListTenanciesResponse Execute(int limit, int cursor);
     }
 }

--- a/TenancyInformationApi/V1/UseCase/ListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/ListTenancies.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using TenancyInformationApi.V1.Boundary.Response;
+using TenancyInformationApi.V1.Domain;
 using TenancyInformationApi.V1.Factories;
 using TenancyInformationApi.V1.Gateways;
 
@@ -13,13 +17,22 @@ namespace TenancyInformationApi.V1.UseCase
             _gateway = gateway;
         }
 
-        public ListTenanciesResponse Execute()
+        public ListTenanciesResponse Execute(int limit, int cursor)
         {
-            var tenancies = _gateway.ListTenancies();
+            limit = limit < 10 ? 10 : limit;
+            limit = limit > 100 ? 100 : limit;
+
+            var tenancies = _gateway.ListTenancies(limit, cursor);
             return new ListTenanciesResponse
             {
-                Tenancies = tenancies.ToResponse()
+                Tenancies = tenancies.ToResponse(),
+                NextCursor = tenancies.Count == limit ? GetNextCursor(tenancies) : null
             };
+        }
+
+        private static string GetNextCursor(List<Tenancy> tenancies)
+        {
+            return tenancies.Max(t => Convert.ToInt32(t.TenancyAgreementReference.Replace("/", ""))).ToString();
         }
     }
 }


### PR DESCRIPTION
This pagination uses the Tag Ref, with the slash removed, as a cursor to numerically order and offset the results.

The limit has a maximum value of 100, minimum of 10 and default of 20. 

If either query parameter is provided in a non-integer form then asp net will automatically return a Bad Request response. 