### PR TITLE
Increase max limit + improve list tenancies query speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,10 @@ lint:
 	-dotnet tool install -g dotnet-format
 	dotnet tool update -g dotnet-format
 	dotnet format
+
+.PHONY: restart-db
+restart-db:
+	docker stop $$(docker ps -q --filter ancestor=test-database -a)
+	-docker rm $$(docker ps -q --filter ancestor=test-database -a)
+	docker rmi test-database
+	docker-compose up -d test-database

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ To run database tests locally (e.g. via Visual Studio) the `CONNECTION_STRING` e
 
 Note: The Host name needs to be the name of the stub database docker-compose service, in order to run tests via Docker.
 
+If changes to the [database schema](https://github.com/LBHackney-IT/tenancy-information-api/blob/master/database/schema.sql) are made then the docker image for the database will have to be removed and recreated. The `restart-db` make command will do this for you.
+
 ### Agreed Testing Approach
 - Use nUnit, FluentAssertions and Moq
 - Always follow a TDD approach

--- a/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
+++ b/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
@@ -74,8 +74,8 @@ namespace TenancyInformationApi.Tests.V1.UseCase
         [Test]
         public void IfLimitMoreThanTheMaximumWillUseTheMaximumLimit()
         {
-            SetupMockGatewayToExpectParameters(limit: 100);
-            CallUseCaseWithArgs(400, 0);
+            SetupMockGatewayToExpectParameters(limit: 1000);
+            CallUseCaseWithArgs(4736, 0);
             _mockGateway.Verify();
         }
 

--- a/TenancyInformationApi/V1/UseCase/ListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/ListTenancies.cs
@@ -23,7 +23,7 @@ namespace TenancyInformationApi.V1.UseCase
             bool leaseholdsOnly, bool freeholdsOnly)
         {
             limit = limit < 10 ? 10 : limit;
-            limit = limit > 100 ? 100 : limit;
+            limit = limit > 1000 ? 1000 : limit;
             CheckPostcodeValid(postcodeQuery);
 
             var tenancies = _gateway.ListTenancies(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly);


### PR DESCRIPTION
Tenancies is a very large dataset and increasing the max limit allows consumers to make fewer calls to retrieve tenancies needed.

This splits the main query into two, first getting all the tag refs that will be returned and then gets all the details relating for those tag refs. Previously it was getting all of the tenancy details and then looping around them and individually retrieving all of the residents.

After also adding a couple of indexes, if it isn't running from a cold start it can now get 1000 records in ~1s.