### PR TITLE
Add person number to the residents response object

### DIFF
--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -49,7 +49,8 @@ namespace TenancyInformationApi.Tests
                     {
                         FirstName = resident.FirstName,
                         LastName = resident.LastName,
-                        DateOfBirth = resident.DateOfBirth.ToString("yyyy-MM-dd")
+                        DateOfBirth = resident.DateOfBirth.ToString("yyyy-MM-dd"),
+                        PersonNumber = resident.PersonNumber
                     }
                 }
             };

--- a/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
+++ b/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
@@ -108,13 +108,15 @@ namespace TenancyInformationApi.Tests.V1.Factories
             {
                 FirstName = "first name",
                 LastName = "last name",
-                DateOfBirth = new DateTime(1980, 12, 28)
+                DateOfBirth = new DateTime(1980, 12, 28),
+                PersonNumber = 4
             };
             dbResident.ToDomain().Should().BeEquivalentTo(new Resident
             {
                 FirstName = "first name",
                 LastName = "last name",
-                DateOfBirth = new DateTime(1980, 12, 28)
+                DateOfBirth = new DateTime(1980, 12, 28),
+                PersonNumber = 4
             });
         }
 

--- a/TenancyInformationApi/V1/Boundary/Response/TenancyInformationResponse.cs
+++ b/TenancyInformationApi/V1/Boundary/Response/TenancyInformationResponse.cs
@@ -27,5 +27,6 @@ namespace TenancyInformationApi.V1.Boundary.Response
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string DateOfBirth { get; set; }
+        public int PersonNumber { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Domain/Tenancy.cs
+++ b/TenancyInformationApi/V1/Domain/Tenancy.cs
@@ -28,5 +28,6 @@ namespace TenancyInformationApi.V1.Domain
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public DateTime? DateOfBirth { get; set; }
+        public int PersonNumber { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -27,7 +27,8 @@ namespace TenancyInformationApi.V1.Factories
             {
                 FirstName = resident.FirstName,
                 LastName = resident.LastName,
-                DateOfBirth = residentDateOfBirth
+                DateOfBirth = residentDateOfBirth,
+                PersonNumber = resident.PersonNumber,
             };
         }
 

--- a/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
@@ -44,7 +44,8 @@ namespace TenancyInformationApi.V1.Factories
             {
                 FirstName = r.FirstName,
                 LastName = r.LastName,
-                DateOfBirth = r.DateOfBirth?.ToString("yyyy-MM-dd")
+                DateOfBirth = r.DateOfBirth?.ToString("yyyy-MM-dd"),
+                PersonNumber = r.PersonNumber
             }).ToList();
         }
     }


### PR DESCRIPTION
Whilst creating features using this API MaT realised that they needed the person number included in the resident information returned.

This PR just includes that in the response. It is a column in the same table so is just a matter of mapping to our domain then response objects to be returned. 

I have also included this in our swagger docs. 