### PR TITLE
Add title and response fields to the resident response

### DIFF
--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -50,7 +50,9 @@ namespace TenancyInformationApi.Tests
                         FirstName = resident.FirstName,
                         LastName = resident.LastName,
                         DateOfBirth = resident.DateOfBirth.ToString("yyyy-MM-dd"),
-                        PersonNumber = resident.PersonNumber
+                        PersonNumber = resident.PersonNumber,
+                        Responsible = resident.Responsible,
+                        Title = resident.Title
                     }
                 }
             };

--- a/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
+++ b/TenancyInformationApi.Tests/V1/Factories/TenancyFactoryTests.cs
@@ -106,17 +106,21 @@ namespace TenancyInformationApi.Tests.V1.Factories
         {
             var dbResident = new UHResident
             {
+                Title = "miss",
                 FirstName = "first name",
                 LastName = "last name",
                 DateOfBirth = new DateTime(1980, 12, 28),
-                PersonNumber = 4
+                PersonNumber = 4,
+                Responsible = false
             };
             dbResident.ToDomain().Should().BeEquivalentTo(new Resident
             {
+                Title = "miss",
                 FirstName = "first name",
                 LastName = "last name",
                 DateOfBirth = new DateTime(1980, 12, 28),
-                PersonNumber = 4
+                PersonNumber = 4,
+                Responsible = false
             });
         }
 

--- a/TenancyInformationApi/V1/Boundary/Response/TenancyInformationResponse.cs
+++ b/TenancyInformationApi/V1/Boundary/Response/TenancyInformationResponse.cs
@@ -24,9 +24,11 @@ namespace TenancyInformationApi.V1.Boundary.Response
 
     public class Resident
     {
+        public string Title { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string DateOfBirth { get; set; }
         public int PersonNumber { get; set; }
+        public bool Responsible { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Domain/Tenancy.cs
+++ b/TenancyInformationApi/V1/Domain/Tenancy.cs
@@ -25,9 +25,11 @@ namespace TenancyInformationApi.V1.Domain
 
     public class Resident
     {
+        public string Title { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public DateTime? DateOfBirth { get; set; }
         public int PersonNumber { get; set; }
+        public bool Responsible { get; set; }
     }
 }

--- a/TenancyInformationApi/V1/Factories/TenancyFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyFactory.cs
@@ -25,10 +25,12 @@ namespace TenancyInformationApi.V1.Factories
                 : resident.DateOfBirth;
             return new Resident
             {
+                Title = resident.Title,
                 FirstName = resident.FirstName,
                 LastName = resident.LastName,
                 DateOfBirth = residentDateOfBirth,
                 PersonNumber = resident.PersonNumber,
+                Responsible = resident.Responsible
             };
         }
 

--- a/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
+++ b/TenancyInformationApi/V1/Factories/TenancyResponseFactory.cs
@@ -45,7 +45,9 @@ namespace TenancyInformationApi.V1.Factories
                 FirstName = r.FirstName,
                 LastName = r.LastName,
                 DateOfBirth = r.DateOfBirth?.ToString("yyyy-MM-dd"),
-                PersonNumber = r.PersonNumber
+                PersonNumber = r.PersonNumber,
+                Responsible = r.Responsible,
+                Title = r.Title
             }).ToList();
         }
     }


### PR DESCRIPTION
MaT need the extra fields Title and Responsible in the resident response for use in their application.

The fields are both in the member table (which is where we currently get resident information from) so this PR just includes them in the database response then maps them to the response object.

As a part of this work, I have also added these fields into the [swagger doc](https://app.swaggerhub.com/apis/Hackney/tenancy-information-api/1.0.0).