### PR TITLE
Search by property reference

### DIFF
--- a/TenancyInformationApi.Tests/E2ETestHelper.cs
+++ b/TenancyInformationApi.Tests/E2ETestHelper.cs
@@ -10,16 +10,16 @@ namespace TenancyInformationApi.Tests
     {
         public static TenancyInformationResponse AddPersonWithRelatedEntitiesToDb(UhContext context,
             string tenancyReference = null, string agreementId = null, string tenureTypeId = null,
-            string address = null, string postcode = null)
+            string address = null, string postcode = null, string propertyReference = null)
         {
             var agreementLookup = AddAgreementTypeToDatabase(context, agreementId);
             var tenureTypeLookup = AddTenureTypeToDatabase(context, tenureTypeId);
 
-            var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference, agreementLookup.UhAgreementTypeId, tenureTypeLookup.UhTenureTypeId);
+            var tenancyAgreement = TestHelper.CreateDatabaseTenancyEntity(tenancyReference, agreementLookup.UhAgreementTypeId, propertyReference, tenureTypeLookup.UhTenureTypeId);
             context.UhTenancyAgreements.Add(tenancyAgreement);
             context.SaveChanges();
 
-            var property = TestHelper.CreateDatabaseProperty(tenancyAgreement.PropertyReference, address, postcode);
+            var property = TestHelper.CreateDatabaseProperty(propertyReference ?? tenancyAgreement.PropertyReference, address, postcode);
             context.UhProperties.Add(property);
             context.SaveChanges();
 
@@ -31,7 +31,7 @@ namespace TenancyInformationApi.Tests
             {
                 TenancyAgreementReference = tenancyAgreement.TenancyAgreementReference,
                 HouseholdReference = tenancyAgreement.HouseholdReference,
-                PropertyReference = tenancyAgreement.PropertyReference,
+                PropertyReference = property.PropertyReference,
                 Address = property.AddressLine1,
                 Postcode = property.Postcode,
                 PaymentReference = tenancyAgreement.PaymentReference,

--- a/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
+++ b/TenancyInformationApi.Tests/V1/Controllers/TenancyInformationControllerTests.cs
@@ -75,7 +75,7 @@ namespace TenancyInformationApi.Tests.V1.Controllers
             };
             _listTenancies
                 .Setup(x => x.Execute(queryParameters.Limit, queryParameters.Cursor, It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Returns(stubbedResponse);
             var response = _classUnderTest.ListTenancies(queryParameters) as ObjectResult;
             response.StatusCode.Should().Be(200);
@@ -91,7 +91,7 @@ namespace TenancyInformationApi.Tests.V1.Controllers
             };
             _listTenancies
                 .Setup(x => x.Execute(20, 0, It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Returns(stubbedResponse);
             var response = _classUnderTest.ListTenancies(new QueryParameters()) as ObjectResult;
             response.StatusCode.Should().Be(200);
@@ -106,11 +106,13 @@ namespace TenancyInformationApi.Tests.V1.Controllers
                 Address = _fixture.Create<string>(),
                 Postcode = _fixture.Create<string>(),
                 FreeholdsOnly = _fixture.Create<bool>(),
-                LeaseholdsOnly = _fixture.Create<bool>()
+                LeaseholdsOnly = _fixture.Create<bool>(),
+                PropertyReference = _fixture.Create<string>()
             };
             _classUnderTest.ListTenancies(queryParameters);
             _listTenancies.Verify(x => x.Execute(It.IsAny<int>(), It.IsAny<int>(),
-                queryParameters.Address, queryParameters.Postcode, queryParameters.LeaseholdsOnly, queryParameters.FreeholdsOnly));
+                queryParameters.Address, queryParameters.Postcode, queryParameters.LeaseholdsOnly,
+                queryParameters.FreeholdsOnly, queryParameters.PropertyReference));
         }
 
         [Test]
@@ -118,7 +120,7 @@ namespace TenancyInformationApi.Tests.V1.Controllers
         {
             _listTenancies
                 .Setup(x => x.Execute(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(),
-                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                    It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Throws(new InvalidQueryParameterException("The parameters are all wrong"));
             var response = _classUnderTest.ListTenancies(new QueryParameters()) as ObjectResult;
             response.StatusCode.Should().Be(400);

--- a/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
+++ b/TenancyInformationApi.Tests/V1/E2ETests/ListTenancies.cs
@@ -159,6 +159,24 @@ namespace TenancyInformationApi.Tests.V1.E2ETests
             returnedTenancies.Tenancies.First().Should().BeEquivalentTo(expectedResponses.First());
         }
 
+        [Test]
+        public async Task WithPropertyReferenceQueryParameterReturnMatchingTenancies()
+        {
+            var expectedResponses = new List<TenancyInformationResponse>
+            {
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "12345/2", "a", "x", propertyReference: "458793848572"),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "54326/9", "b", "y", propertyReference: "293885029348"),
+                E2ETestHelper.AddPersonWithRelatedEntitiesToDb(DatabaseContext, "453627/2", "c", "z", propertyReference: "359819238534"),
+            };
+
+            var response = await CallApiListEndpointWithQueryString("?property_reference=458793848572").ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedTenancies = await DeserializeResponse(response).ConfigureAwait(true);
+            returnedTenancies.Tenancies.Count.Should().Be(1);
+            returnedTenancies.Tenancies.First().Should().BeEquivalentTo(expectedResponses.First());
+        }
+
         private static string GetLetterFromAlphabetPosition(int position)
         {
             // Being used to generate ordered string based ID's which are all unique. To help test pagination and prevent duplicate key errors in test setup.

--- a/TenancyInformationApi.Tests/V1/Gateways/TenancyGatewayTests.cs
+++ b/TenancyInformationApi.Tests/V1/Gateways/TenancyGatewayTests.cs
@@ -261,7 +261,7 @@ namespace TenancyInformationApi.Tests.V1.Gateways
                 "DUMMY/Z536"
             };
             fakeTagRefs.ForEach(t => SaveTenancyPropertyAndLookups(tagRef: t, agreementLookupId: t.Last().ToString()));
-            var legitimateTenancy = SaveTenancyPropertyAndLookups("12367/2", "z");
+            var legitimateTenancy = SaveTenancyPropertyAndLookups("12367/2", agreementLookupId: "z");
 
             var response = CallGatewayWithArgs();
             response.Count.Should().Be(1);
@@ -302,23 +302,24 @@ namespace TenancyInformationApi.Tests.V1.Gateways
         }
 
         private (UhTenancyAgreement uhTenancy, UhTenureType tenureTypeLookup, UhAgreementType agreementTypeLookup,
-            UHProperty property) SaveTenancyPropertyAndLookups(string tagRef = null, string agreementLookupId = null, string tenureTypeId = null,
+            UHProperty property) SaveTenancyPropertyAndLookups(string tagRef = null, string propRef = null, string agreementLookupId = null, string tenureTypeId = null,
                 string address = null, string postcode = null)
         {
             var faker = new Faker();
             tagRef ??= $"{faker.Random.Int(0, 99999)}/{faker.Random.Int(0, 99)}";
+            propRef ??= $"{faker.Random.Long(100000000000, 999999999999)}";
             var tenureTypeLookup = AddTenureTypeLookupToDatabase(tenureTypeId);
             var agreementTypeLookup = AddAgreementTypeLookupToDatabase(agreementLookupId);
-            var uhTenancy = AddTenancyAgreementToDatabase(tagRef, agreementTypeLookup, tenureTypeLookup);
+            var uhTenancy = AddTenancyAgreementToDatabase(tagRef, propRef, agreementTypeLookup, tenureTypeLookup);
             var property = AddPropertyToDatabase(uhTenancy.PropertyReference, address, postcode);
             return (uhTenancy, tenureTypeLookup, agreementTypeLookup, property);
         }
 
-        private UhTenancyAgreement AddTenancyAgreementToDatabase(string tagRef, UhAgreementType agreementTypeLookup,
+        private UhTenancyAgreement AddTenancyAgreementToDatabase(string tagRef, string propRef, UhAgreementType agreementTypeLookup,
             UhTenureType tenureTypeLookup)
         {
             var uhTenancy = TestHelper.CreateDatabaseTenancyEntity(tagRef, agreementTypeLookup.UhAgreementTypeId,
-                tenureTypeLookup.UhTenureTypeId);
+                propRef, tenureTypeLookup.UhTenureTypeId);
 
             UhContext.UhTenancyAgreements.Add(uhTenancy);
             UhContext.SaveChanges();

--- a/TenancyInformationApi.Tests/V1/Gateways/TenancyGatewayTests.cs
+++ b/TenancyInformationApi.Tests/V1/Gateways/TenancyGatewayTests.cs
@@ -355,9 +355,9 @@ namespace TenancyInformationApi.Tests.V1.Gateways
             return property;
         }
 
-        private List<Tenancy> CallGatewayWithArgs(int limit = 20, int cursor = 0, string addressQuery = null, string postcodeQuery = null, bool leaseholdsOnly = false, bool freeholdsOnly = false)
+        private List<Tenancy> CallGatewayWithArgs(int limit = 20, int cursor = 0, string addressQuery = null, string postcodeQuery = null, bool leaseholdsOnly = false, bool freeholdsOnly = false, string propertyReference = null)
         {
-            return _classUnderTest.ListTenancies(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly);
+            return _classUnderTest.ListTenancies(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly, propertyReference);
         }
     }
 }

--- a/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
+++ b/TenancyInformationApi.Tests/V1/Helper/TestHelper.cs
@@ -6,7 +6,8 @@ namespace TenancyInformationApi.Tests.V1.Helper
 {
     public static class TestHelper
     {
-        public static UhTenancyAgreement CreateDatabaseTenancyEntity(string tenancyReference, string agreementTypeRef, string tenureTypeLookupId = null)
+        public static UhTenancyAgreement CreateDatabaseTenancyEntity(string tenancyReference, string agreementTypeRef,
+            string propertyReference, string tenureTypeLookupId = null)
         {
             var fixture = new Fixture();
             var fp = fixture.Build<UhTenancyAgreement>()
@@ -15,6 +16,7 @@ namespace TenancyInformationApi.Tests.V1.Helper
                 .Create();
             fp.UhTenureTypeId = tenureTypeLookupId ?? fp.UhTenureTypeId;
             fp.TenancyAgreementReference = tenancyReference ?? fp.TenancyAgreementReference;
+            fp.PropertyReference = propertyReference ?? fp.PropertyReference;
             fp.UhAgreementTypeId = agreementTypeRef.First();
             return fp;
         }

--- a/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
+++ b/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
@@ -151,7 +151,7 @@ namespace TenancyInformationApi.Tests.V1.UseCase
             SetupMockGatewayToExpectParameters(postcodeQuery: postcode);
             _mockPostcodeValidator.Setup(x => x.Execute(postcode)).Returns(false);
 
-            Func<ListTenanciesResponse> testDelegate = () => _classUnderTest.Execute(15, 3, null, postcode, false, false);
+            Func<ListTenanciesResponse> testDelegate = () => _classUnderTest.Execute(15, 3, null, postcode, false, false, null);
             testDelegate.Should().Throw<InvalidQueryParameterException>()
                 .WithMessage("The Postcode given does not have a valid format");
         }
@@ -178,11 +178,11 @@ namespace TenancyInformationApi.Tests.V1.UseCase
 
         private void SetupMockGatewayToExpectParameters(int? limit = null, int? cursor = null,
             string addressQuery = null, string postcodeQuery = null, bool leaseholdsOnly = false, bool freeholdsOnly = false,
-            IEnumerable<Tenancy> stubbedTenancies = null)
+            IEnumerable<Tenancy> stubbedTenancies = null, string propertyReference = null)
         {
             _mockGateway
                 .Setup(x =>
-                    x.ListTenancies(It.Is<int>(l => CheckParameter(limit, l)), cursor ?? It.IsAny<int>(), addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly))
+                    x.ListTenancies(It.Is<int>(l => CheckParameter(limit, l)), cursor ?? It.IsAny<int>(), addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly, propertyReference))
                 .Returns(stubbedTenancies?.ToList() ?? new List<Tenancy>()).Verifiable();
         }
 
@@ -192,9 +192,9 @@ namespace TenancyInformationApi.Tests.V1.UseCase
         }
 
         private ListTenanciesResponse CallUseCaseWithArgs(int limit, int cursor, string address = null, string postcode = null,
-            bool leaseholdsOnly = false, bool freeholdsOnly = false)
+            bool leaseholdsOnly = false, bool freeholdsOnly = false, string propertyReference = null)
         {
-            return _classUnderTest.Execute(limit, cursor, address, postcode, leaseholdsOnly, freeholdsOnly);
+            return _classUnderTest.Execute(limit, cursor, address, postcode, leaseholdsOnly, freeholdsOnly, propertyReference);
         }
     }
 }

--- a/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
+++ b/TenancyInformationApi.Tests/V1/UseCase/ListTenanciesTests.cs
@@ -145,6 +145,16 @@ namespace TenancyInformationApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void ExecuteCallsTheGatewayWithPropertyReferenceQueryParameter()
+        {
+            var propertyReference = _fixture.Create<string>();
+            SetupMockGatewayToExpectParameters(propertyReference: propertyReference);
+
+            CallUseCaseWithArgs(20, 0, propertyReference: propertyReference);
+            _mockGateway.Verify();
+        }
+
+        [Test]
         public void IfPostcodeQueryIsInvalidExecuteWillReturnBadRequest()
         {
             var postcode = "E8881DY";

--- a/TenancyInformationApi/V1/Boundary/QueryParameters.cs
+++ b/TenancyInformationApi/V1/Boundary/QueryParameters.cs
@@ -11,6 +11,9 @@ namespace TenancyInformationApi.V1.Boundary
         [FromQuery(Name = "postcode")]
         public string Postcode { get; set; }
 
+        [FromQuery(Name = "property_reference")]
+        public string PropertyReference { get; set; }
+
         [FromQuery(Name = "freehold_only")]
         [DefaultValue(false)]
         public bool FreeholdsOnly { get; set; } = false;

--- a/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
+++ b/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
@@ -36,8 +36,9 @@ namespace TenancyInformationApi.V1.Controllers
         {
             try
             {
-                return Ok(_listTenancies.Execute(queryParameters.Limit, queryParameters.Cursor, queryParameters.Address,
-                    queryParameters.Postcode, queryParameters.LeaseholdsOnly, queryParameters.FreeholdsOnly));
+                return Ok(_listTenancies.Execute(queryParameters.Limit, queryParameters.Cursor,
+                            queryParameters.Address, queryParameters.Postcode, queryParameters.LeaseholdsOnly,
+                            queryParameters.FreeholdsOnly, queryParameters.PropertyReference));
 
             }
             catch (InvalidQueryParameterException exception)

--- a/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
+++ b/TenancyInformationApi/V1/Controllers/TenancyInformationController.cs
@@ -39,7 +39,6 @@ namespace TenancyInformationApi.V1.Controllers
                 return Ok(_listTenancies.Execute(queryParameters.Limit, queryParameters.Cursor,
                             queryParameters.Address, queryParameters.Postcode, queryParameters.LeaseholdsOnly,
                             queryParameters.FreeholdsOnly, queryParameters.PropertyReference));
-
             }
             catch (InvalidQueryParameterException exception)
             {

--- a/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/ITenancyGateway.cs
@@ -6,6 +6,6 @@ namespace TenancyInformationApi.V1.Gateways
     public interface ITenancyGateway
     {
         Tenancy GetById(string id);
-        List<Tenancy> ListTenancies(int limit, int cursor, string addressQuery, string postcodeQuery, bool leaseholdsOnly, bool freeholdsOnly);
+        List<Tenancy> ListTenancies(int limit, int cursor, string addressQuery, string postcodeQuery, bool leaseholdsOnly, bool freeholdsOnly, string propertyReference);
     }
 }

--- a/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
@@ -31,10 +31,11 @@ namespace TenancyInformationApi.V1.Gateways
             return tenancyAgreement.ToDomain(agreementLookup);
         }
 
-        public List<Tenancy> ListTenancies(int limit, int cursor, string addressQuery, string postcodeQuery, bool leaseholdsOnly, bool freeholdsOnly)
+        public List<Tenancy> ListTenancies(int limit, int cursor, string addressQuery, string postcodeQuery,
+                bool leaseholdsOnly, bool freeholdsOnly, string propertyReference)
         {
             var tagRefsToRetrieve = TagRefsToReturn(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly,
-                freeholdsOnly);
+                freeholdsOnly, propertyReference);
             var tenancies = GetTenancyDetailsForTagRefs(tagRefsToRetrieve);
 
             return GroupByTagRefAndMapToDomain(tenancies);
@@ -86,7 +87,7 @@ namespace TenancyInformationApi.V1.Gateways
         }
 
         private List<string> TagRefsToReturn(int limit, int cursor, string addressQuery, string postcodeQuery, bool leaseholdsOnly,
-            bool freeholdsOnly)
+            bool freeholdsOnly, string propertyReference)
         {
             var invalidTagRefList = GetInvalidTagRefList();
             var addressSearchPattern = GetSearchPattern(addressQuery);
@@ -112,6 +113,8 @@ namespace TenancyInformationApi.V1.Gateways
                       || EF.Functions.ILike(property.Postcode.Replace(" ", ""), addressSearchPattern)
                 where string.IsNullOrEmpty(postcodeQuery)
                       || EF.Functions.ILike(property.Postcode.Replace(" ", ""), postcodeSearchPattern)
+                where string.IsNullOrEmpty(propertyReference)
+                      || EF.Functions.ILike(property.PropertyReference.Replace(" ", ""), propertyReference)
                 orderby tagRefFormattedForPagination
                 select agreement.TenancyAgreementReference
             ).Take(limit).ToList();

--- a/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
+++ b/TenancyInformationApi/V1/Gateways/TenancyGateway.cs
@@ -98,8 +98,7 @@ namespace TenancyInformationApi.V1.Gateways
                 join tenureType in _uhContext.UhTenure on agreement.UhTenureTypeId equals tenureType.UhTenureTypeId
                 join agreementType in _uhContext.UhTenancyAgreementsType on agreement.UhAgreementTypeId.ToString()
                     equals agreementType.UhAgreementTypeId.Trim()
-                join property in _uhContext.UhProperties on agreement.PropertyReference equals property
-                    .PropertyReference
+                join property in _uhContext.UhProperties on agreement.PropertyReference equals property.PropertyReference
                 let tagRefFormattedForPagination =
                     Convert.ToInt32(agreement.TenancyAgreementReference.Replace("/", "").Replace("Z", ""))
                 where !invalidTagRefList.Contains(agreement.TenancyAgreementReference)
@@ -114,7 +113,7 @@ namespace TenancyInformationApi.V1.Gateways
                 where string.IsNullOrEmpty(postcodeQuery)
                       || EF.Functions.ILike(property.Postcode.Replace(" ", ""), postcodeSearchPattern)
                 where string.IsNullOrEmpty(propertyReference)
-                      || EF.Functions.ILike(property.PropertyReference.Replace(" ", ""), propertyReference)
+                      || EF.Functions.ILike(property.PropertyReference, propertyReference)
                 orderby tagRefFormattedForPagination
                 select agreement.TenancyAgreementReference
             ).Take(limit).ToList();

--- a/TenancyInformationApi/V1/UseCase/IListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/IListTenancies.cs
@@ -4,6 +4,7 @@ namespace TenancyInformationApi.V1.UseCase
 {
     public interface IListTenancies
     {
-        ListTenanciesResponse Execute(int limit, int cursor, string addressQuery, string postcodeQuery, bool leaseholdsOnly, bool freeholdsOnly);
+        ListTenanciesResponse Execute(int limit, int cursor, string addressQuery, string postcodeQuery,
+                bool leaseholdsOnly, bool freeholdsOnly, string propertyReference);
     }
 }

--- a/TenancyInformationApi/V1/UseCase/ListTenancies.cs
+++ b/TenancyInformationApi/V1/UseCase/ListTenancies.cs
@@ -20,13 +20,14 @@ namespace TenancyInformationApi.V1.UseCase
         }
 
         public ListTenanciesResponse Execute(int limit, int cursor, string addressQuery, string postcodeQuery,
-            bool leaseholdsOnly, bool freeholdsOnly)
+                bool leaseholdsOnly, bool freeholdsOnly, string propertyReference)
         {
-            limit = limit < 10 ? 10 : limit;
-            limit = limit > 1000 ? 1000 : limit;
+            limit = Clamp(limit, 10, 1000);
             CheckPostcodeValid(postcodeQuery);
 
-            var tenancies = _gateway.ListTenancies(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly, freeholdsOnly);
+            var tenancies = _gateway.ListTenancies(limit, cursor, addressQuery, postcodeQuery, leaseholdsOnly,
+                    freeholdsOnly, propertyReference);
+
             return new ListTenanciesResponse
             {
                 Tenancies = tenancies.ToResponse(),
@@ -50,5 +51,8 @@ namespace TenancyInformationApi.V1.UseCase
             var validPostcode = _validatePostcode.Execute(postcode);
             if (!validPostcode) throw new InvalidQueryParameterException("The Postcode given does not have a valid format");
         }
+
+        private static int Clamp(int value, int min, int max) =>
+            (value < min) ? min : (value > max) ? max : value;
     }
 }


### PR DESCRIPTION
Provide functionality to search tenancies by property reference.
Feature requested for Repairs API v2

### *What changes have we introduced*

Add property reference query parameter

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

